### PR TITLE
Fix dependencies for Contao 4.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.6.0",
         "contao/core-bundle": "^4.4",
         "erusev/parsedown": "~1.6",
-        "menatwork/contao-multicolumnwizard-bundle": "^3.4",
+        "menatwork/contao-multicolumnwizard": "^3.3"
         "wa72/htmlpagedom": "^2.0",
         "knplabs/github-api": "^2.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "contao/core-bundle": "^4.4",
         "erusev/parsedown": "~1.6",
         "menatwork/contao-multicolumnwizard-bundle": "^3.4",
-        "wa72/htmlpagedom": "^1.3",
+        "wa72/htmlpagedom": "^2.0",
         "knplabs/github-api": "^2.11"
     },
     "require-dev": {


### PR DESCRIPTION
I had to downgrade the multicolumn-wizard for compatibility reasons, see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/107

Maybe it's a good idea to merge this PR into an own branch (e.g. hotfix-c4.11). I did not test in Contao  < 4.11